### PR TITLE
fixed leak (forgot to delete list), added <iostream> for std::cout

### DIFF
--- a/test/test_SSLL.cpp
+++ b/test/test_SSLL.cpp
@@ -2,6 +2,8 @@
 
 #include "SSLL.h"
 
+#include <iostream>
+
 SCENARIO ("INTERFACE TEST") {
 	GIVEN ("An SSLL of characters is created") {
 		cop3530::List<char> *list = new cop3530::SSLL<char>();
@@ -94,6 +96,7 @@ SCENARIO ("INTERFACE TEST") {
 			}
 		}
 	}
+	delete list;
 }
 
 


### PR DESCRIPTION
my SSLL class includes <ostream> but std::cout needs <iostream>